### PR TITLE
update to bootstrap-icons v1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bootstrap-icons",
-  "version": "1.5.0",
+  "version": "1.8.1",
   "description": "Bootstrap's SVG icons converted to react-native-svg components",
   "main": "index.js",
   "types": "./icons/index.d.ts",
@@ -37,7 +37,7 @@
     "@svgr/plugin-svgo": "^5.5.0",
     "@types/react": "^17.0.0",
     "@types/react-native": "^0.63.37",
-    "bootstrap-icons": "^1.5.0",
+    "bootstrap-icons": "^1.8.1",
     "glob": "^7.1.6",
     "prettier": "^2.2.1",
     "react-native-svg": "^12.1.0",


### PR DESCRIPTION
Update to bootstrap icons Version 1.8.1

https://blog.getbootstrap.com/2022/01/31/bootstrap-icons-1-8-0/